### PR TITLE
Add custom permissions to book-service-api

### DIFF
--- a/books/permissions.py
+++ b/books/permissions.py
@@ -1,0 +1,12 @@
+from rest_framework import permissions
+
+
+class IsAdminOrReadOnly(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return bool(
+            (request.method in permissions.SAFE_METHODS
+            and request.user
+             )
+            or (request.user and request.user.is_staff)
+
+        )

--- a/books/views.py
+++ b/books/views.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets
 
+from books import permissions
 from books.models import Book
 from books.serializers import BookSerializer, BookListSerializers, BookDetailSerializer
 
@@ -7,6 +8,7 @@ from books.serializers import BookSerializer, BookListSerializers, BookDetailSer
 class BookViewSet(viewsets.ModelViewSet):
     queryset = Book.objects.all()
     serializer_class = BookSerializer
+    permission_classes = (permissions.IsAdminOrReadOnly,)
 
     def get_serializer_class(self):
         if self.action == 'list':


### PR DESCRIPTION
Add custom permissions so that only admin is able to create/update/delete books, but users can only view available books (independent of wheter the user is authenticated)